### PR TITLE
Add config to publish "jsdoc2" in the bin dir.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,15 @@
 	},
 	"name": "jsdoc2",
 	"description": "A port of JSDoc2 Toolkit that runs on Node",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"repository": {
 		"type": "git",
 		"url": "git://github.com/wronex/node-jsdoc2.git"
 	},
 	"homepage": "http://wronex.github.com/node-jsdoc2",
+	"bin": {
+		"jsdoc2": "./app/run.js"
+	},
 	"contributors": [
 		{
 			"name": "wronex",


### PR DESCRIPTION
This will publish app/run.js as "jsdoc2" in node_modules/.bin/jsdoc2 so that anyone that has that dot bin dir in their path will automatically be able to execute it.